### PR TITLE
Adding power support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: ruby
 sudo: false
-rvm: 2.5.1
+rvm: 2.4.1
 env:
   global:
   - CHIRP_SUMMARY_OUTPUT="${TRAVIS_BUILD_DIR}/chirp.json"
   - SITE=org
+  - CHIRP_S3_REPEATS=0
 addons: { apt: { packages: [bc] } }
 linux_shared: &linux_shared
   os: linux
+  os: linux-ppc64le
   addons: { apt: { packages: [bc] } }
 matrix:
   include:
@@ -31,6 +33,14 @@ matrix:
     osx_image: xcode7
     rvm: default
     env: QUEUE=macstadium6 IMAGE=xcode7
+  - sudo: false
+    dist: xenial
+    env: QUEUE=builds.power.container DIST=xenial
+    <<: *linux_shared
+  - sudo: required
+    dist: xenial
+    env: QUEUE=builds.power DIST=xenial
+    <<: *linux_shared
 before_install:
 - gem update --system
 - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 sudo: false
-rvm: 2.4.1
+rvm: 2.5.1
 env:
   global:
   - CHIRP_SUMMARY_OUTPUT="${TRAVIS_BUILD_DIR}/chirp.json"
@@ -8,20 +8,21 @@ env:
   - CHIRP_S3_REPEATS=0
 addons: { apt: { packages: [bc] } }
 linux_shared: &linux_shared
-  os: linux
-  os: linux-ppc64le
   addons: { apt: { packages: [bc] } }
 matrix:
   include:
-  - sudo: false
+  - os: linux
+    sudo: false
     dist: trusty
     env: QUEUE=ec2 DIST=trusty
     <<: *linux_shared
-  - sudo: required
+  - os: linux
+    sudo: required
     dist: trusty
     env: QUEUE=gce DIST=trusty
     <<: *linux_shared
-  - sudo: required
+  - os: linux
+    sudo: required
     dist: xenial
     group: edge
     env: QUEUE=gce DIST=xenial
@@ -33,12 +34,15 @@ matrix:
     osx_image: xcode7
     rvm: default
     env: QUEUE=macstadium6 IMAGE=xcode7
-  - sudo: false
+  - os: linux-ppc64le
+    sudo: false
     dist: xenial
+    rvm: default
     env: QUEUE=builds.power.container DIST=xenial
     <<: *linux_shared
   - sudo: required
     dist: xenial
+    rvm: default
     env: QUEUE=builds.power DIST=xenial
     <<: *linux_shared
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ matrix:
     rvm: default
     env: QUEUE=builds.power.container DIST=xenial
     <<: *linux_shared
-  - sudo: required
+  - os: linux-ppc64le
+    sudo: required
     dist: xenial
     rvm: default
     env: QUEUE=builds.power DIST=xenial


### PR DESCRIPTION
Making an attempt to add power support
 

- Added Power queue using "os:linux-ppc64le" for vm and container deployments.
- Select "rvm:default" for power.
- adding this global variable - "CHIRP_S3_REPEATS=0" to resolve build errors.

Travis job passing as well - https://travis-ci.org/ghatwala/chirp-org-production/builds/432910750 

@meatballhat  - could you please check and review ? 
